### PR TITLE
Fixes for Kernel 4.14

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -253,8 +253,14 @@ void sdfat_time_unix2fat(struct sdfat_sb_info *sbi, struct timespec *ts,
 
 TIMESTAMP_T *tm_now(struct sdfat_sb_info *sbi, TIMESTAMP_T *tp)
 {
-	struct timespec ts = CURRENT_TIME_SEC;
+	struct timespec ts;
 	DATE_TIME_T dt;
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+	ts = CURRENT_TIME_SEC;
+#else
+	ktime_get_real_ts(&ts);
+#endif
 
 	sdfat_time_unix2fat(sbi, &ts, &dt);
 
@@ -378,4 +384,3 @@ void __sdfat_dmsg(int level, const char *fmt, ...)
 #endif
 }
 #endif
-

--- a/mpage.c
+++ b/mpage.c
@@ -94,7 +94,11 @@ static inline void __sdfat_submit_bio_write2(int flags, struct bio *bio)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
 static void  mpage_write_end_io(struct bio *bio)
 {
-	__mpage_write_end_io(bio, bio->bi_error);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+	__sdfat_writepage_end_io(bio, bio->bi_status);
+#else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0) */
+	__sdfat_writepage_end_io(bio, bio->bi_error);
+#endif
 }
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0) */
 static void mpage_write_end_io(struct bio *bio, int err)
@@ -277,7 +281,11 @@ mpage_alloc(struct block_device *bdev,
 	}
 
 	if (bio) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+		bio_set_dev(bio, bdev);
+#else
 		bio->bi_bdev = bdev;
+#endif
 		__sdfat_set_bio_sector(bio, first_sector);
 	}
 	return bio;
@@ -604,4 +612,3 @@ int sdfat_mpage_writepages(struct address_space *mapping,
 }
 
 #endif /* CONFIG_SDFAT_ALIGNED_MPAGE_WRITE */
-

--- a/sdfat.c
+++ b/sdfat.c
@@ -216,15 +216,14 @@ static inline void inode_unlock(struct inode *inode)
 #endif
 
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+static void sdfat_writepage_end_io(struct bio *bio)
+{
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
-static void sdfat_writepage_end_io(struct bio *bio)
-{
 	__sdfat_writepage_end_io(bio, bio->bi_status);
-}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
-static void sdfat_writepage_end_io(struct bio *bio)
-{
+#else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0) */
 	__sdfat_writepage_end_io(bio, bio->bi_error);
+#endif
 }
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0) */
 static void sdfat_writepage_end_io(struct bio *bio, int err)
@@ -3452,7 +3451,11 @@ static inline void sdfat_submit_fullpage_bio(struct block_device *bdev,
 	 */
 	bio = bio_alloc(GFP_NOIO, 1);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	bio_set_dev(bio, bdev);
+#else
 	bio->bi_bdev = bdev;
+#endif
 	bio->bi_vcnt = 1;
 	bio->bi_io_vec[0].bv_page = page;	/* Inline vec */
 	bio->bi_io_vec[0].bv_len = length;	/* PAGE_SIZE */

--- a/sdfat.c
+++ b/sdfat.c
@@ -68,6 +68,9 @@
 /* skip iterating emit_dots when dir is empty */
 #define ITER_POS_FILLED_DOTS	(2)
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+#define current_time(x)	(CURRENT_TIME_SEC)
+#endif
 /* type index declare at sdfat.h */
 const char *FS_TYPE_STR[] = {
 	"auto",
@@ -2310,7 +2313,6 @@ static int __sdfat_create(struct inode *dir, struct dentry *dentry)
 {
 	struct super_block *sb = dir->i_sb;
 	struct inode *inode;
-	struct timespec ts;
 	FILE_ID_T fid;
 	loff_t i_pos;
 	int err;
@@ -2319,8 +2321,6 @@ static int __sdfat_create(struct inode *dir, struct dentry *dentry)
 
 	TMSG("%s entered\n", __func__);
 
-	ts = CURRENT_TIME_SEC;
-
 	err = fsapi_create(dir, (u8 *) dentry->d_name.name, FM_REGULAR, &fid);
 	if (err)
 		goto out;
@@ -2328,7 +2328,7 @@ static int __sdfat_create(struct inode *dir, struct dentry *dentry)
 	__lock_d_revalidate(dentry);
 
 	dir->i_version++;
-	dir->i_ctime = dir->i_mtime = dir->i_atime = ts;
+	dir->i_ctime = dir->i_mtime = dir->i_atime = current_time(dir);
 	if (IS_DIRSYNC(dir))
 		(void) sdfat_sync_inode(dir);
 	else
@@ -2341,7 +2341,7 @@ static int __sdfat_create(struct inode *dir, struct dentry *dentry)
 		goto out;
 	}
 	inode->i_version++;
-	inode->i_mtime = inode->i_atime = inode->i_ctime = ts;
+	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	/* timestamp is already written, so mark_inode_dirty() is unneeded. */
 
 	d_instantiate(dentry, inode);
@@ -2475,14 +2475,11 @@ static int sdfat_unlink(struct inode *dir, struct dentry *dentry)
 {
 	struct inode *inode = dentry->d_inode;
 	struct super_block *sb = dir->i_sb;
-	struct timespec ts;
 	int err;
 
 	__lock_super(sb);
 
 	TMSG("%s entered\n", __func__);
-
-	ts = CURRENT_TIME_SEC;
 
 	SDFAT_I(inode)->fid.size = i_size_read(inode);
 
@@ -2495,14 +2492,14 @@ static int sdfat_unlink(struct inode *dir, struct dentry *dentry)
 	__lock_d_revalidate(dentry);
 
 	dir->i_version++;
-	dir->i_mtime = dir->i_atime = ts;
+	dir->i_mtime = dir->i_atime = current_time(dir);
 	if (IS_DIRSYNC(dir))
 		(void) sdfat_sync_inode(dir);
 	else
 		mark_inode_dirty(dir);
 
 	clear_nlink(inode);
-	inode->i_mtime = inode->i_atime = ts;
+	inode->i_mtime = inode->i_atime = current_time(inode);
 	sdfat_detach(inode);
 	dentry->d_time = dir->i_version;
 out:
@@ -2516,7 +2513,6 @@ static int sdfat_symlink(struct inode *dir, struct dentry *dentry, const char *t
 {
 	struct super_block *sb = dir->i_sb;
 	struct inode *inode;
-	struct timespec ts;
 	FILE_ID_T fid;
 	loff_t i_pos;
 	int err;
@@ -2530,8 +2526,6 @@ static int sdfat_symlink(struct inode *dir, struct dentry *dentry, const char *t
 	__lock_super(sb);
 
 	TMSG("%s entered\n", __func__);
-
-	ts = CURRENT_TIME_SEC;
 
 	err = fsapi_create(dir, (u8 *) dentry->d_name.name, FM_SYMLINK, &fid);
 	if (err)
@@ -2547,7 +2541,7 @@ static int sdfat_symlink(struct inode *dir, struct dentry *dentry, const char *t
 	__lock_d_revalidate(dentry);
 
 	dir->i_version++;
-	dir->i_ctime = dir->i_mtime = dir->i_atime = ts;
+	dir->i_ctime = dir->i_mtime = dir->i_atime = current_time(dir);
 	if (IS_DIRSYNC(dir))
 		(void) sdfat_sync_inode(dir);
 	else
@@ -2560,7 +2554,7 @@ static int sdfat_symlink(struct inode *dir, struct dentry *dentry, const char *t
 		goto out;
 	}
 	inode->i_version++;
-	inode->i_mtime = inode->i_atime = inode->i_ctime = ts;
+	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	/* timestamp is already written, so mark_inode_dirty() is unneeded. */
 
 	SDFAT_I(inode)->target = kmalloc((len+1), GFP_KERNEL);
@@ -2583,7 +2577,6 @@ static int __sdfat_mkdir(struct inode *dir, struct dentry *dentry)
 {
 	struct super_block *sb = dir->i_sb;
 	struct inode *inode;
-	struct timespec ts;
 	FILE_ID_T fid;
 	loff_t i_pos;
 	int err;
@@ -2592,8 +2585,6 @@ static int __sdfat_mkdir(struct inode *dir, struct dentry *dentry)
 
 	TMSG("%s entered\n", __func__);
 
-	ts = CURRENT_TIME_SEC;
-
 	err = fsapi_mkdir(dir, (u8 *) dentry->d_name.name, &fid);
 	if (err)
 		goto out;
@@ -2601,7 +2592,7 @@ static int __sdfat_mkdir(struct inode *dir, struct dentry *dentry)
 	__lock_d_revalidate(dentry);
 
 	dir->i_version++;
-	dir->i_ctime = dir->i_mtime = dir->i_atime = ts;
+	dir->i_ctime = dir->i_mtime = dir->i_atime = current_time(dir);
 	if (IS_DIRSYNC(dir))
 		(void) sdfat_sync_inode(dir);
 	else
@@ -2615,7 +2606,7 @@ static int __sdfat_mkdir(struct inode *dir, struct dentry *dentry)
 		goto out;
 	}
 	inode->i_version++;
-	inode->i_mtime = inode->i_atime = inode->i_ctime = ts;
+	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	/* timestamp is already written, so mark_inode_dirty() is unneeded. */
 
 	d_instantiate(dentry, inode);
@@ -2634,14 +2625,11 @@ static int sdfat_rmdir(struct inode *dir, struct dentry *dentry)
 {
 	struct inode *inode = dentry->d_inode;
 	struct super_block *sb = dir->i_sb;
-	struct timespec ts;
 	int err;
 
 	__lock_super(sb);
 
 	TMSG("%s entered\n", __func__);
-
-	ts = CURRENT_TIME_SEC;
 
 	SDFAT_I(inode)->fid.size = i_size_read(inode);
 
@@ -2652,7 +2640,7 @@ static int sdfat_rmdir(struct inode *dir, struct dentry *dentry)
 	__lock_d_revalidate(dentry);
 
 	dir->i_version++;
-	dir->i_mtime = dir->i_atime = ts;
+	dir->i_mtime = dir->i_atime = current_time(dir);
 	if (IS_DIRSYNC(dir))
 		(void) sdfat_sync_inode(dir);
 	else
@@ -2660,7 +2648,7 @@ static int sdfat_rmdir(struct inode *dir, struct dentry *dentry)
 	drop_nlink(dir);
 
 	clear_nlink(inode);
-	inode->i_mtime = inode->i_atime = ts;
+	inode->i_mtime = inode->i_atime = current_time(inode);
 	sdfat_detach(inode);
 	dentry->d_time = dir->i_version;
 out:
@@ -2675,7 +2663,6 @@ static int __sdfat_rename(struct inode *old_dir, struct dentry *old_dentry,
 {
 	struct inode *old_inode, *new_inode;
 	struct super_block *sb = old_dir->i_sb;
-	struct timespec ts;
 	loff_t i_pos;
 	int err;
 
@@ -2685,8 +2672,6 @@ static int __sdfat_rename(struct inode *old_dir, struct dentry *old_dentry,
 
 	old_inode = old_dentry->d_inode;
 	new_inode = new_dentry->d_inode;
-
-	ts = CURRENT_TIME_SEC;
 
 	SDFAT_I(old_inode)->fid.size = i_size_read(old_inode);
 
@@ -2700,7 +2685,7 @@ static int __sdfat_rename(struct inode *old_dir, struct dentry *old_dentry,
 	__lock_d_revalidate(new_dentry);
 
 	new_dir->i_version++;
-	new_dir->i_ctime = new_dir->i_mtime = new_dir->i_atime = ts;
+	new_dir->i_ctime = new_dir->i_mtime = new_dir->i_atime = current_time(new_dir);
 	if (IS_DIRSYNC(new_dir))
 		(void) sdfat_sync_inode(new_dir);
 	else
@@ -2721,7 +2706,7 @@ static int __sdfat_rename(struct inode *old_dir, struct dentry *old_dentry,
 	}
 
 	old_dir->i_version++;
-	old_dir->i_ctime = old_dir->i_mtime = ts;
+	old_dir->i_ctime = old_dir->i_mtime = current_time(old_dir);
 	if (IS_DIRSYNC(old_dir))
 		(void) sdfat_sync_inode(old_dir);
 	else
@@ -2740,7 +2725,7 @@ static int __sdfat_rename(struct inode *old_dir, struct dentry *old_dentry,
 				__func__);
 			WARN_ON(new_inode->i_nlink == 0);
 		}
-		new_inode->i_ctime = ts;
+		new_inode->i_ctime = current_time(new_inode);
 #if 0
 		(void) sdfat_sync_inode(new_inode);
 #endif
@@ -2764,7 +2749,7 @@ static int sdfat_cont_expand(struct inode *inode, loff_t size)
 	if (err)
 		return err;
 
-	inode->i_ctime = inode->i_mtime = CURRENT_TIME_SEC;
+	inode->i_ctime = inode->i_mtime = current_time(inode);
 	mark_inode_dirty(inode);
 
 	if (!IS_SYNC(inode))
@@ -3017,7 +3002,7 @@ static void sdfat_truncate(struct inode *inode, loff_t old_size)
 	if (err)
 		goto out;
 
-	inode->i_ctime = inode->i_mtime = CURRENT_TIME_SEC;
+	inode->i_ctime = inode->i_mtime = current_time(inode);
 	if (IS_DIRSYNC(inode))
 		(void) sdfat_sync_inode(inode);
 	else
@@ -3722,7 +3707,7 @@ static int sdfat_write_end(struct file *file, struct address_space *mapping,
 		sdfat_write_failed(mapping, pos+len);
 
 	if (!(err < 0) && !(fid->attr & ATTR_ARCHIVE)) {
-		inode->i_mtime = inode->i_ctime = CURRENT_TIME_SEC;
+		inode->i_mtime = inode->i_ctime = current_time(inode);
 		fid->attr |= ATTR_ARCHIVE;
 		mark_inode_dirty(inode);
 	}
@@ -4728,11 +4713,8 @@ static int sdfat_read_root(struct inode *inode)
 {
 	struct super_block *sb = inode->i_sb;
 	struct sdfat_sb_info *sbi = SDFAT_SB(sb);
-	struct timespec ts;
 	FS_INFO_T *fsi = &(sbi->fsi);
 	DIR_ENTRY_T info;
-
-	ts = CURRENT_TIME_SEC;
 
 	SDFAT_I(inode)->fid.dir.dir = fsi->root_dir;
 	SDFAT_I(inode)->fid.dir.flags = 0x01;
@@ -4769,7 +4751,7 @@ static int sdfat_read_root(struct inode *inode)
 	SDFAT_I(inode)->i_size_ondisk = i_size_read(inode);
 
 	sdfat_save_attr(inode, ATTR_SUBDIR);
-	inode->i_mtime = inode->i_atime = inode->i_ctime = ts;
+	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	set_nlink(inode, info.NumSubdirs + 2);
 	return 0;
 }

--- a/sdfat.c
+++ b/sdfat.c
@@ -216,7 +216,12 @@ static inline void inode_unlock(struct inode *inode)
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+static void sdfat_writepage_end_io(struct bio *bio)
+{
+	__sdfat_writepage_end_io(bio, bio->bi_status);
+}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
 static void sdfat_writepage_end_io(struct bio *bio)
 {
 	__sdfat_writepage_end_io(bio, bio->bi_error);
@@ -5124,4 +5129,3 @@ module_exit(exit_sdfat_fs);
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("FAT/exFAT filesystem support");
 MODULE_AUTHOR("Samsung Electronics Co., Ltd.");
-


### PR DESCRIPTION
Now it compiles on 4.14 Linux Kernel. 
I tested on 4.14.31 on amd64, seems to work fine.

It may work as well on 4.15 since there was no big changes between 4.14 and 4.15, but I didn't tested.

It also should work as on all versions below 4.14, but I didn't tested as well.