### PR TITLE
fs: sdfat: Fix frag_ratio formula

### DIFF
--- a/dfr.c
+++ b/dfr.c
@@ -1248,7 +1248,7 @@ defrag_check_defrag_required(
 		frag_ratio = ((amap->n_au - amap->n_clean_au) * 100) / amap->n_full_au;
 	else
 		frag_ratio = ((amap->n_au - amap->n_clean_au) * 100) /
-					(fsi->used_clusters * CLUS_PER_AU(sb));
+					(fsi->used_clusters / CLUS_PER_AU(sb) + 1);
 
 	/*
 	 * Wake-up defrag_daemon:


### PR DESCRIPTION
When there is no full au in AMAP, if we use the number of non-clean au
divides fsi->used_clusters * CLUS_PER_AU(sb), the frag_ratio is always
smaller than (or equal with) 100%, which is not right.

Actually, frag_ratio should be the the ratio that non-clean aus divides
the number of aus if all used_clusters are contiguous.

Signed-off-by: Noctis Ackerman <noctis.akm@gmail.com>